### PR TITLE
Add polished calculus tutoring landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="UCalgary-based calculus tutoring led by second-year students who specialize in Calc II and advanced calculus." />
+  <title>Limitless Calculus Tutoring | UCalgary Student Tutors</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Sora:wght@500;600&display=swap"
+    rel="stylesheet"
+  />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div class="glow glow--one" aria-hidden="true"></div>
+  <div class="glow glow--two" aria-hidden="true"></div>
+  <header class="site-header" id="top">
+    <nav class="nav container" aria-label="Main navigation">
+      <a class="logo" href="#top">Limitless Calculus</a>
+      <button class="nav__toggle" aria-expanded="false" aria-label="Toggle navigation">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+      <ul class="nav__links">
+        <li><a href="#about">Why Us</a></li>
+        <li><a href="#tutors">Meet the Tutors</a></li>
+        <li><a href="#pricing">Pricing</a></li>
+        <li><a href="#contact">Contact</a></li>
+        <li><a class="nav__cta" href="#contact">Book Now</a></li>
+      </ul>
+    </nav>
+
+    <section class="hero container" aria-labelledby="hero-title">
+      <div class="hero__text">
+        <span class="tag">Calgary · In-person & Online</span>
+        <h1 id="hero-title">Master calculus with UCalgary student tutors who speak your language.</h1>
+        <p>
+          We are two second-year University of Calgary students obsessed with helping high schoolers conquer
+          calculus. One of us is acing Calc II right now, and the other is diving into MATH 375 (Advanced Calculus) —
+          so you get fresh, firsthand strategies that work in the classroom today.
+        </p>
+        <div class="hero__ctas">
+          <a class="btn" href="#contact">Book a 1:1 session</a>
+          <a class="btn btn--ghost" href="#about">See how we help</a>
+        </div>
+        <dl class="hero__stats">
+          <div>
+            <dt>Calc II insiders</dt>
+            <dd>Learn the same techniques powering <span class="accent">top marks</span> in university right now.</dd>
+          </div>
+          <div>
+            <dt>MATH 375 ready</dt>
+            <dd>Bridge into proofs, rigor, and multivariable thinking without feeling overwhelmed.</dd>
+          </div>
+          <div>
+            <dt>Built for high school</dt>
+            <dd>AP, IB, and diploma prep crafted specifically for Alberta students.</dd>
+          </div>
+        </dl>
+      </div>
+      <aside class="hero__card" aria-label="Quick highlight of what you get">
+        <h2>What sets us apart</h2>
+        <ul>
+          <li><strong>Weekly drop-ins</strong> for homework rescue &amp; exam sprints.</li>
+          <li><strong>Concept-first approach</strong> with visuals, intuition, and quick checks.</li>
+          <li><strong>Personalized study blueprints</strong> so you know exactly what to tackle next.</li>
+        </ul>
+        <p class="note">Need a personalized detail (e.g., your name, achievements)? Swap the placeholders anytime.</p>
+      </aside>
+    </section>
+  </header>
+
+  <main>
+    <section id="about" class="section container" aria-labelledby="about-title">
+      <header class="section__head">
+        <span class="tag">Why choose Limitless Calculus?</span>
+        <h2 id="about-title">Modern tutoring built to make hard math click fast.</h2>
+        <p>
+          We blend real university experience with high school curriculum expertise. Expect fast-paced clarity,
+          structured practice, and mentorship from tutors who were in your seat only a couple of semesters ago.
+        </p>
+      </header>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <h3>Built for Alberta curriculum</h3>
+          <p>Diploma-aligned plans, IB / AP extensions, and pacing that syncs with local classrooms.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Beyond rote memorization</h3>
+          <p>Intuitive explanations, visual walkthroughs, and active recall drills to cement understanding.</p>
+        </article>
+        <article class="feature-card">
+          <h3>Session recaps &amp; action steps</h3>
+          <p>Every meeting ends with a micro-plan so you always know how to keep momentum between lessons.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="tutors" class="section section--alt" aria-labelledby="tutor-title">
+      <div class="container">
+        <header class="section__head">
+          <span class="tag">Meet your tutors</span>
+          <h2 id="tutor-title">Peers, mentors, and hype team — all in one.</h2>
+        </header>
+        <div class="tutor-grid">
+          <article class="tutor-card">
+            <div class="tutor-card__header">
+              <h3><span class="placeholder">Your Name Here</span></h3>
+              <p class="role">BSc Mathematics (UCalgary) · Heading into MATH 375</p>
+            </div>
+            <p>
+              Specializes in building deep conceptual frameworks, transitioning students from memorization to mastery.
+              Passionate about making epsilon-delta ideas approachable and guiding students into proof-based thinking.
+            </p>
+            <ul class="tutor-card__list">
+              <li>Designs colourful visual notes and desmos-powered explorations.</li>
+              <li>Perfect for AP Calculus BC extensions and advanced diploma prep.</li>
+            </ul>
+          </article>
+
+          <article class="tutor-card">
+            <div class="tutor-card__header">
+              <h3><span class="placeholder">Friend's Name Here</span></h3>
+              <p class="role">BSc Engineering (UCalgary) · Currently in Calc II</p>
+            </div>
+            <p>
+              Laser-focused on problem-solving speed and exam tactics. Breaks down derivatives, integrals, and series with
+              step-by-step clarity that matches today’s university expectations.
+            </p>
+            <ul class="tutor-card__list">
+              <li>Brings live examples straight from current lectures and assignments.</li>
+              <li>Great for quick confidence boosts before quizzes or unit tests.</li>
+            </ul>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="pricing" class="section container" aria-labelledby="pricing-title">
+      <header class="section__head">
+        <span class="tag">Invest in your calculus confidence</span>
+        <h2 id="pricing-title">Flexible options for every schedule.</h2>
+      </header>
+      <div class="pricing-grid">
+        <article class="pricing-card">
+          <div class="pricing-card__top">
+            <h3>Starter Session</h3>
+            <p class="price">$<span class="placeholder">xx</span> / 60 min</p>
+          </div>
+          <p>Perfect for homework help or a focused exam review sprint.</p>
+          <ul>
+            <li>Custom diagnostic check-in</li>
+            <li>Take-home recap sheet</li>
+            <li>Email support for 3 days</li>
+          </ul>
+          <a class="btn" href="#contact">Book this</a>
+        </article>
+
+        <article class="pricing-card pricing-card--accent">
+          <div class="pricing-card__top">
+            <h3>Momentum Package</h3>
+            <p class="price">$<span class="placeholder">xx</span> / 4 sessions</p>
+          </div>
+          <p>Our most popular plan for building long-term understanding and exam readiness.</p>
+          <ul>
+            <li>Weekly or bi-weekly sessions</li>
+            <li>Personalized study roadmap</li>
+            <li>Progress tracking dashboard</li>
+          </ul>
+          <a class="btn btn--light" href="#contact">Get started</a>
+        </article>
+
+        <article class="pricing-card">
+          <div class="pricing-card__top">
+            <h3>Team Workshop</h3>
+            <p class="price">$<span class="placeholder">xx</span> / group</p>
+          </div>
+          <p>Bring a friend or two for collaborative problem solving and shared costs.</p>
+          <ul>
+            <li>2-4 students per session</li>
+            <li>Game-style challenge sets</li>
+            <li>Shared notes &amp; recordings</li>
+          </ul>
+          <a class="btn" href="#contact">Save a spot</a>
+        </article>
+      </div>
+    </section>
+
+    <section id="testimonials" class="section section--alt" aria-labelledby="testimonials-title">
+      <div class="container">
+        <header class="section__head">
+          <span class="tag">Social proof</span>
+          <h2 id="testimonials-title">Swap in your wins here.</h2>
+          <p>Add real feedback or success stats once you start collecting them. For now, use these as placeholders.</p>
+        </header>
+        <div class="testimonial-grid">
+          <figure class="testimonial-card">
+            <blockquote>
+              “I finally understood limits — and went from a 68% to an 88% on my unit test in two weeks.”
+            </blockquote>
+            <figcaption>— <span class="placeholder">Grade 12 student, Centennial High School</span></figcaption>
+          </figure>
+          <figure class="testimonial-card">
+            <blockquote>
+              “Their study plan kept me accountable and calm heading into the diploma. Highly recommend.”
+            </blockquote>
+            <figcaption>— <span class="placeholder">Parent of Grade 11 student</span></figcaption>
+          </figure>
+          <figure class="testimonial-card">
+            <blockquote>
+              “The mix of intuition and practice problems made AP Calculus BC way less scary.”
+            </blockquote>
+            <figcaption>— <span class="placeholder">AP Calculus BC student</span></figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section id="contact" class="section container" aria-labelledby="contact-title">
+      <div class="contact-card">
+        <header>
+          <span class="tag">Ready when you are</span>
+          <h2 id="contact-title">Let’s build your calculus confidence.</h2>
+          <p>
+            Tell us a bit about your goals, schedule, and pain points. We’ll reply within 24 hours with next steps and a
+            link to secure your session.
+          </p>
+        </header>
+        <div class="contact-layout">
+          <form class="contact-form" action="#" method="post">
+            <label>
+              Name
+              <input type="text" name="name" placeholder="First &amp; last name" required />
+            </label>
+            <label>
+              Email
+              <input type="email" name="email" placeholder="you@example.com" required />
+            </label>
+            <label>
+              What are you working on?
+              <select name="focus" required>
+                <option value="" selected disabled>Select an option</option>
+                <option value="ib">IB / AP Calculus</option>
+                <option value="diploma">Diploma prep</option>
+                <option value="homework">Weekly homework support</option>
+                <option value="enrichment">Enrichment / acceleration</option>
+              </select>
+            </label>
+            <label>
+              Message
+              <textarea name="message" rows="4" placeholder="Share classes, timelines, or anything we should know."></textarea>
+            </label>
+            <button type="submit" class="btn">Send message</button>
+          </form>
+          <div class="contact-info">
+            <div class="info-block">
+              <h3>Contact</h3>
+              <p><span class="placeholder">hello@limitlesscalculus.ca</span></p>
+              <p><span class="placeholder">(403) 000-0000</span></p>
+            </div>
+            <div class="info-block">
+              <h3>Availability</h3>
+              <ul>
+                <li>Weekday evenings (online)</li>
+                <li>Weekend mornings (in-person @ UCalgary or local cafés)</li>
+              </ul>
+            </div>
+            <div class="info-block">
+              <h3>Follow along</h3>
+              <ul class="social-list">
+                <li><a href="#">Instagram</a></li>
+                <li><a href="#">Discord</a></li>
+                <li><a href="#">YouTube Shorts</a></li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <p>© <span id="year"></span> Limitless Calculus Tutoring. Built by second-year UCalgary students.</p>
+      <a href="#top" class="back-to-top">Back to top ↑</a>
+    </div>
+  </footer>
+
+  <script>
+    const nav = document.querySelector('.nav');
+    const toggle = document.querySelector('.nav__toggle');
+    const navLinks = document.querySelectorAll('.nav__links a');
+
+    if (nav && toggle) {
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        nav.classList.toggle('is-open');
+      });
+
+      navLinks.forEach((link) =>
+        link.addEventListener('click', () => {
+          toggle.setAttribute('aria-expanded', 'false');
+          nav.classList.remove('is-open');
+        })
+      );
+    }
+
+    const yearSpan = document.getElementById('year');
+    if (yearSpan) {
+      yearSpan.textContent = new Date().getFullYear();
+    }
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,726 @@
+:root {
+  --bg: radial-gradient(circle at 15% 20%, rgba(77, 115, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 85% 15%, rgba(97, 244, 222, 0.18), transparent 50%), #040611;
+  --surface: rgba(14, 19, 35, 0.88);
+  --surface-alt: rgba(15, 22, 43, 0.95);
+  --card: rgba(19, 28, 56, 0.8);
+  --text: #eef3ff;
+  --subtle: #a7b7d9;
+  --accent: #61f4de;
+  --accent-strong: #4d73ff;
+  --danger: #ff5a91;
+  --border: rgba(114, 133, 187, 0.24);
+  --shadow: 0 20px 40px rgba(5, 14, 36, 0.45);
+  --container: min(1100px, 92vw);
+  --radius-large: 28px;
+  --radius-medium: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+  position: relative;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: var(--container);
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.site-header {
+  position: relative;
+  padding: 3.5rem 0 5rem;
+  overflow: hidden;
+}
+
+.logo {
+  font-family: 'Sora', 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 1.2rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.glow {
+  position: fixed;
+  width: 480px;
+  height: 480px;
+  filter: blur(120px);
+  opacity: 0.55;
+  z-index: 1;
+  pointer-events: none;
+  transition: opacity 0.6s ease;
+}
+
+.glow--one {
+  top: -120px;
+  left: -80px;
+  background: radial-gradient(circle, rgba(77, 115, 255, 0.8), transparent 70%);
+}
+
+.glow--two {
+  bottom: 60px;
+  right: -140px;
+  background: radial-gradient(circle, rgba(97, 244, 222, 0.8), transparent 70%);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 0.75rem 1.2rem;
+  background: rgba(6, 9, 20, 0.65);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-large);
+  box-shadow: 0 15px 35px rgba(3, 6, 14, 0.35);
+  position: sticky;
+  top: 1.5rem;
+  backdrop-filter: blur(18px);
+  z-index: 10;
+}
+
+.nav__links {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  margin: 0;
+  padding: 0;
+  font-size: 0.95rem;
+}
+
+.nav__links a {
+  padding: 0.45rem 0.75rem;
+  border-radius: 12px;
+  transition: color 0.2s ease, background 0.2s ease;
+}
+
+.nav__links a:hover,
+.nav__links a:focus {
+  background: rgba(97, 244, 222, 0.12);
+}
+
+.nav__cta {
+  border: 1px solid rgba(97, 244, 222, 0.5);
+  color: var(--accent);
+}
+
+.nav__toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 5px;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid rgba(151, 167, 205, 0.3);
+  background: rgba(9, 13, 28, 0.6);
+  color: inherit;
+  cursor: pointer;
+  transition: border 0.2s ease, background 0.2s ease;
+}
+
+.nav__toggle span {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--text);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav.is-open .nav__toggle span:first-child {
+  transform: translateY(7px) rotate(45deg);
+}
+
+.nav.is-open .nav__toggle span:nth-child(2) {
+  opacity: 0;
+}
+
+.nav.is-open .nav__toggle span:last-child {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.hero {
+  margin-top: 4rem;
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+}
+
+.hero__text {
+  display: flex;
+  flex-direction: column;
+  gap: 1.6rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(151, 167, 205, 0.4);
+  font-size: 0.78rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--subtle);
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: 'Sora', 'Inter', sans-serif;
+  margin: 0;
+  color: var(--text);
+}
+
+h1 {
+  font-size: clamp(2.4rem, 4vw + 1.2rem, 3.6rem);
+  line-height: 1.1;
+}
+
+.hero__text p {
+  margin: 0;
+  color: var(--subtle);
+  font-size: 1.02rem;
+}
+
+.hero__ctas {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.65rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  color: #02030b;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  box-shadow: 0 15px 35px rgba(33, 70, 160, 0.35);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 40px rgba(33, 70, 160, 0.45);
+}
+
+.btn.btn--ghost {
+  background: rgba(11, 17, 38, 0.6);
+  color: var(--text);
+  border: 1px solid rgba(151, 167, 205, 0.35);
+  box-shadow: none;
+}
+
+.btn.btn--ghost:hover,
+.btn.btn--ghost:focus {
+  background: rgba(16, 25, 50, 0.95);
+}
+
+.btn.btn--light {
+  background: #0d1327;
+  color: var(--accent);
+  box-shadow: none;
+  border: 1px solid rgba(97, 244, 222, 0.4);
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.4rem;
+  margin: 0;
+}
+
+.hero__stats dt {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 0.78rem;
+  color: rgba(231, 239, 255, 0.85);
+}
+
+.hero__stats dd {
+  margin: 0.35rem 0 0;
+  color: var(--subtle);
+  font-size: 0.92rem;
+}
+
+.accent {
+  color: var(--accent);
+}
+
+.hero__card {
+  background: linear-gradient(155deg, rgba(24, 34, 68, 0.9), rgba(17, 26, 54, 0.95));
+  padding: 2.4rem;
+  border-radius: var(--radius-large);
+  border: 1px solid rgba(114, 133, 187, 0.26);
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero__card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(97, 244, 222, 0.18), transparent 60%);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.hero__card h2 {
+  font-size: 1.4rem;
+  margin-bottom: 1.2rem;
+}
+
+.hero__card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+  color: var(--subtle);
+}
+
+.hero__card li::before {
+  content: '✦';
+  margin-right: 0.6rem;
+  color: var(--accent);
+}
+
+.hero__card .note {
+  margin-top: 1.6rem;
+  font-size: 0.82rem;
+  color: rgba(167, 183, 217, 0.8);
+}
+
+.section {
+  padding: 5rem 0;
+  position: relative;
+}
+
+.section--alt {
+  background: rgba(9, 14, 30, 0.65);
+  border-top: 1px solid rgba(114, 133, 187, 0.2);
+  border-bottom: 1px solid rgba(114, 133, 187, 0.2);
+}
+
+.section__head {
+  max-width: 680px;
+  display: grid;
+  gap: 1.2rem;
+  margin-bottom: 3rem;
+}
+
+.section__head p {
+  margin: 0;
+  color: var(--subtle);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.6rem;
+}
+
+.feature-card,
+.tutor-card,
+.pricing-card,
+.testimonial-card,
+.contact-card {
+  background: var(--card);
+  border-radius: var(--radius-large);
+  padding: 2rem;
+  border: 1px solid rgba(114, 133, 187, 0.22);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+}
+
+.feature-card h3 {
+  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+}
+
+.feature-card p {
+  margin: 0;
+  color: var(--subtle);
+}
+
+.tutor-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.8rem;
+}
+
+.tutor-card {
+  display: grid;
+  gap: 1.1rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.tutor-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(97, 244, 222, 0.12), transparent 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.tutor-card:hover::after {
+  opacity: 1;
+}
+
+.tutor-card__header {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.tutor-card h3 {
+  font-size: 1.2rem;
+}
+
+.role {
+  margin: 0;
+  color: rgba(167, 183, 217, 0.9);
+  font-size: 0.9rem;
+}
+
+.tutor-card p {
+  margin: 0;
+  color: var(--subtle);
+}
+
+.tutor-card__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+  color: rgba(199, 210, 235, 0.9);
+  font-size: 0.92rem;
+}
+
+.tutor-card__list li::before {
+  content: '→';
+  color: var(--accent);
+  margin-right: 0.5rem;
+}
+
+.placeholder {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.8rem;
+}
+
+.pricing-card {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.pricing-card__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.price {
+  font-size: 1.4rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.pricing-card ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.6rem;
+  color: var(--subtle);
+}
+
+.pricing-card ul li::before {
+  content: '✔';
+  color: var(--accent);
+  margin-right: 0.5rem;
+}
+
+.pricing-card--accent {
+  background: linear-gradient(155deg, rgba(33, 51, 105, 0.95), rgba(17, 25, 50, 0.95));
+  border: 1px solid rgba(97, 244, 222, 0.35);
+}
+
+.btn.btn--light:hover,
+.btn.btn--light:focus {
+  background: rgba(11, 19, 41, 0.95);
+}
+
+.testimonial-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.6rem;
+}
+
+.testimonial-card {
+  display: grid;
+  gap: 1.2rem;
+  font-style: italic;
+  color: rgba(214, 223, 255, 0.92);
+}
+
+.testimonial-card blockquote {
+  margin: 0;
+}
+
+.testimonial-card figcaption {
+  font-style: normal;
+  color: var(--subtle);
+}
+
+.contact-card {
+  display: grid;
+  gap: 2rem;
+}
+
+.contact-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
+  gap: 2rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 0.55rem;
+  font-size: 0.9rem;
+  color: rgba(203, 214, 246, 0.92);
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(151, 167, 205, 0.35);
+  background: rgba(6, 10, 21, 0.85);
+  color: var(--text);
+  font: inherit;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact-form input:focus,
+.contact-form select:focus,
+.contact-form textarea:focus {
+  outline: none;
+  border-color: rgba(97, 244, 222, 0.7);
+  box-shadow: 0 0 0 3px rgba(97, 244, 222, 0.15);
+}
+
+.contact-form textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.contact-info {
+  background: rgba(9, 14, 30, 0.7);
+  border-radius: var(--radius-medium);
+  padding: 1.8rem;
+  border: 1px solid rgba(114, 133, 187, 0.2);
+  display: grid;
+  gap: 1.4rem;
+}
+
+.info-block h3 {
+  margin: 0 0 0.5rem;
+}
+
+.info-block p,
+.info-block ul {
+  margin: 0;
+  color: var(--subtle);
+}
+
+.info-block ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.social-list {
+  display: inline-flex;
+  gap: 1rem;
+  font-size: 0.92rem;
+}
+
+.social-list a {
+  border-bottom: 1px solid rgba(97, 244, 222, 0.25);
+  padding-bottom: 0.1rem;
+}
+
+.site-footer {
+  padding: 3rem 0 2.5rem;
+  text-align: center;
+  color: rgba(167, 183, 217, 0.8);
+  font-size: 0.9rem;
+}
+
+.back-to-top {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--accent);
+}
+
+@media (max-width: 960px) {
+  .nav__links {
+    gap: 0.9rem;
+  }
+}
+
+@media (max-width: 820px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .hero__card {
+    order: -1;
+  }
+
+  .contact-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .nav {
+    padding: 0.5rem 0.75rem;
+  }
+
+  .nav__toggle {
+    display: inline-flex;
+  }
+
+  .nav__links {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 1rem;
+    background: rgba(6, 10, 24, 0.95);
+    border: 1px solid rgba(114, 133, 187, 0.2);
+    border-radius: var(--radius-medium);
+    padding: 1rem 1.2rem;
+    min-width: 200px;
+    display: grid;
+    gap: 0.4rem;
+    box-shadow: var(--shadow);
+    opacity: 0;
+    transform: translateY(-10px);
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+  }
+
+  .nav.is-open .nav__links {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .nav__links li:last-child {
+    margin-top: 0.4rem;
+  }
+
+  .hero__ctas {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 560px) {
+  .site-header {
+    padding: 2.8rem 0 4rem;
+  }
+
+  .section {
+    padding: 4rem 0;
+  }
+
+  .feature-grid,
+  .tutor-grid,
+  .pricing-grid,
+  .testimonial-grid {
+    gap: 1.2rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .glow {
+    opacity: 0.4;
+  }
+}
+
+::selection {
+  background: rgba(97, 244, 222, 0.25);
+  color: var(--text);
+}


### PR DESCRIPTION
## Summary
- create a single-page site highlighting offerings, tutor bios, pricing, testimonials, and contact CTAs for the calculus tutoring service
- craft responsive styling with gradients, glassmorphism cards, and mobile navigation to deliver a modern standout look
- include placeholders for personal details plus a lead form and CTA buttons for future booking integrations

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c89bd79ae08321bd7601d787a39fe6